### PR TITLE
Vertical becomes unit

### DIFF
--- a/openedx_blockstore_relay/tests/test_transfer_data.py
+++ b/openedx_blockstore_relay/tests/test_transfer_data.py
@@ -84,7 +84,7 @@ class TransferBlockTestCase(ModuleStoreTestCase):
         }
 
         self.assertXmlEqual(file_data_by_path['/unit1_1_2.olx'], '''
-            <vertical
+            <unit
                 url_name="unit1_1_2"
                 xmlns:block="http://code.edx.org/xblock/block" xmlns:option="http://code.edx.org/xblock/option"
             >
@@ -108,7 +108,7 @@ class TransferBlockTestCase(ModuleStoreTestCase):
                 <drag-and-drop-v2
                     url_name="dnd" display_name="A Drag and Drop Block (Pure XBlock)" xblock-family="xblock.v1"
                 />
-            </vertical>
+            </unit>
         ''')
 
         self.assertXmlEqual(

--- a/openedx_blockstore_relay/transfer_data.py
+++ b/openedx_blockstore_relay/transfer_data.py
@@ -138,9 +138,27 @@ class TransferBlock(object):
             block.add_xml_to_node(olx_node)
             self._queue_related_files(filesystem)
 
+        self.transform_olx(olx_node)
+
         self._queue_olx(olx_node, block)
         self._block_olx_ok[block_key] = True
         return olx_node
+
+    def transform_olx(self, olx_node):
+        """
+        Apply transformations to the given OLX etree Node.
+
+        Specifically, we convert the <vertical> tag to the
+        <unit> tag, which is preferred for use in Blockstore.
+        (Unit is more generic, has less tech debt, and is
+        not coupled so tightly to the Open edX LMS runtime UI.)
+        """
+        for node in olx_node.iter():
+            if node.tag == 'vertical':
+                node.tag = 'unit'
+                for key in node.attrib.keys():
+                    if key not in ('display_name', 'url_name'):
+                        LOG.warn('<vertical> tag attribute "%s" will be ignored after conversion to <unit>', key)
 
     def queue_manifest(self, name='bundle.json', path=os.sep):
         """


### PR DESCRIPTION
This PR will automatically convert `<vertical>` to `<unit>` when importing a "Unit" from Studio to Blockstore.

Depends on:
- https://github.com/open-craft/unit-xblock/pull/1
- #4 

Testing instructions:
* Import a `vertical` into Blockstore, and confirm that the OLX says `<unit>` instead of `<vertical>`
* Check that the updated tests are passing.